### PR TITLE
Remove permissions to unbreak the tray icon

### DIFF
--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -4,15 +4,13 @@ runtime-version: '44'
 sdk: org.gnome.Sdk
 command: spotube
 finish-args:
-- --socket=fallback-x11
-- --socket=wayland
+- --socket=x11
 - --socket=pulseaudio
 - --share=network
 - --share=ipc
 - --device=dri
 - --filesystem=xdg-download
 - --talk-name=org.freedesktop.Notifications
-- --talk-name=org.kde.StatusNotifierWatcher
 - --talk-name=org.freedesktop.secrets
 - --filesystem=xdg-documents
 - --filesystem=xdg-run/pipewire-0:ro


### PR DESCRIPTION
**NOTE:** This is not the proper fix by any means; It's only a workaround.

This PR removes both `--talk-name=org.kde.StatusNotifierWatcher` and `--socket=wayland` permissions to unbreak the tray icon functionality.

The root cause likely needs to be addressed in [this third-party library](https://github.com/antler119/system_tray) that Spotube uses to set up the tray icon. 

Also see https://github.com/antler119/system_tray/issues/67#issuecomment-1879840114 for more details.

---

Using `dbus-monitor`, we can figure out how Spotube is setting the tray icon:


```
$ dbus-monitor
...
   array [
      dict entry(
         string "Id"
         variant             string "cac90a20-a943-11ee-86a7-d9e05156d7eb"
      )
      dict entry(
         string "Category"
         variant             string "ApplicationStatus"
      )
      dict entry(
         string "Status"
         variant             string "Active"
      )
      dict entry(
         string "IconName"
         variant             string "/app/spotube/data/flutter_assets/assets/spotube-logo.png"
      )
...
```

The problem here is that the path for the icon file in the `IconName` property does not exist outside of the Flatpak sandbox, and therefore the icon file cannot be found or set.

By removing the `--talk-name=org.kde.StatusNotifierWatcher` permission, however, xdg-desktop-portal takes care of this problem for us automagically.

At least on KDE, instead of forwarding the literal path of the icon, only the pixmap data of the icon is sent, through the `IconPixmap` option:


```
$ dbus-monitor
...
   array [
      dict entry(
         string "Category"
         variant             string "ApplicationStatus"
      )
      dict entry(
         string "IconPixmap"
         variant             array [
               struct {
                  int32 16
                  int32 16
                  array of bytes [
                     ff 00 00 00 ff 00 00 00 ff 00 00 00 ff 00 00 00 ff 00 00
                     [ ... output shortened for readability ... ]
                  ]
               }
            ]
      )
...
```

Although this fixes things on X11 sessions, that's still not enough for Wayland, so that's why it's needed to also remove the Wayland permission so that XWayland is used instead.

Fixes https://github.com/KRTirtho/spotube/issues/541