### PR TITLE
Allow access to Avahi D-Bus

### DIFF
--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -14,6 +14,7 @@ finish-args:
 - --talk-name=org.freedesktop.Notifications
 - --talk-name=org.kde.StatusNotifierWatcher
 - --talk-name=org.freedesktop.secrets
+- --system-talk-name=org.freedesktop.Avahi.*
 - --filesystem=xdg-documents
 - --filesystem=xdg-run/pipewire-0:ro
 - --own-name=org.mpris.MediaPlayer2.Spotube.*


### PR DESCRIPTION
Spotube's Connect feature requires it for announcing through mDNS. I've tested and works as expected.