### PR TITLE
Updated Session Bus Policy

### DIFF
--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -17,7 +17,7 @@ finish-args:
 - --system-talk-name=org.freedesktop.Avahi.*
 - --filesystem=xdg-documents
 - --filesystem=xdg-run/pipewire-0:ro
-- --own-name=org.mpris.MediaPlayer2.Spotube.*
+- --own-name=org.mpris.MediaPlayer2.com.krtirtho.Spotube.*
 modules:
 - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
 - shared-modules/libsecret/libsecret.json


### PR DESCRIPTION
Updated Session Bus Policy to fix Media Player detection in KDE.

![image](https://github.com/flathub/com.github.KRTirtho.Spotube/assets/85226365/30f88661-c006-42c9-ab2a-f28ad135dd8d)
