### PR TITLE
Update runtime 49

### DIFF
--- a/12509c0f1ee8c22ae163017f0a5e7b8a9d983a17.patch
+++ b/12509c0f1ee8c22ae163017f0a5e7b8a9d983a17.patch
@@ -1,0 +1,31 @@
+From 12509c0f1ee8c22ae163017f0a5e7b8a9d983a17 Mon Sep 17 00:00:00 2001
+From: Nicolas Chauvet <kwizart@gmail.com>
+Date: Tue, 29 Jul 2025 11:42:35 +0200
+Subject: [PATCH] vulkan/utils_gen: fix for python 3.14
+
+Python 3.14+ has added more type checking. This patch fixes usage
+
+Fixes: https://github.com/haasn/libplacebo/issues/335
+
+Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>
+---
+ src/vulkan/utils_gen.py | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/src/vulkan/utils_gen.py b/src/vulkan/utils_gen.py
+index 9a97d35f3..9b803d82b 100644
+--- a/src/vulkan/utils_gen.py
++++ b/src/vulkan/utils_gen.py
+@@ -202,7 +202,8 @@ if __name__ == '__main__':
+     if not xmlfile or xmlfile == '':
+         xmlfile = find_registry_xml(datadir)
+ 
+-    registry = VkXML(ET.parse(xmlfile))
++    tree = ET.parse(xmlfile)
++    registry = VkXML(tree.getroot())
+     with open(outfile, 'w') as f:
+         f.write(TEMPLATE.render(
+             vkresults = get_vkenum(registry, 'VkResult'),
+-- 
+GitLab
+

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -4,13 +4,6 @@ runtime: org.gnome.Platform
 runtime-version: "49"
 sdk: org.gnome.Sdk
 command: spotube
-add-extensions:
-  org.freedesktop.Platform.ffmpeg-full:
-    version: '25.08'
-    directory: lib/ffmpeg
-    add-ld-path: .
-cleanup-commands:
-  - mkdir -p ${FLATPAK_DEST}/lib/ffmpeg
 finish-args:
   - --socket=fallback-x11
   - --socket=wayland

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -1,12 +1,12 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/flatpak/flatpak-builder/main/data/flatpak-manifest.schema.json
 app-id: com.github.KRTirtho.Spotube
 runtime: org.gnome.Platform
-runtime-version: "48"
+runtime-version: "49"
 sdk: org.gnome.Sdk
 command: spotube
 add-extensions:
   org.freedesktop.Platform.ffmpeg-full:
-    version: '24.08'
+    version: '25.08'
     directory: lib/ffmpeg
     add-ld-path: .
 cleanup-commands:

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -121,6 +121,8 @@ modules:
               type: anitya
               project-id: 300234
               url-template: https://github.com/Dav1dde/glad/archive/refs/tags/v$version.tar.gz
+          - type: patch
+            path: 12509c0f1ee8c22ae163017f0a5e7b8a9d983a17.patch
 
       - name: libass
         config-opts:

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -29,7 +29,6 @@ finish-args:
   - --own-name=org.mpris.MediaPlayer2.spotube.*
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
-  - shared-modules/libsecret/libsecret.json
   - name: libnotify
     buildsystem: meson
     config-opts:

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -98,8 +98,8 @@ modules:
           - -Ddemos=False
         sources:
           - type: archive
-            url: https://code.videolan.org/videolan/libplacebo/-/archive/v7.349.0/libplacebo-v7.349.0.tar.gz
-            sha256: 79120e685a1836344b51b13b6a5661622486a84e4d4a35f6c8d01679a20fbc86
+            url: https://code.videolan.org/videolan/libplacebo/-/archive/v7.351.0/libplacebo-v7.351.0.tar.gz
+            sha256: 4efe1c8d4da3c61295eb5fdfa50e6037409d8425eb3c15dd86788679c4ce59ee
             x-checker-data:
               type: anitya
               project-id: 20101

--- a/com.github.KRTirtho.Spotube.yml
+++ b/com.github.KRTirtho.Spotube.yml
@@ -20,19 +20,12 @@ finish-args:
   - --filesystem=xdg-run/pipewire-0:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:create
   - --own-name=org.mpris.MediaPlayer2.spotube.*
+cleanup:
+  - /include
+  - /lib/pkgconfig
 modules:
   - shared-modules/libappindicator/libappindicator-gtk3-12.10.json
-  - name: libnotify
-    buildsystem: meson
-    config-opts:
-      - -Dtests=false
-      - -Dintrospection=disabled
-      - -Dgtk_doc=false
-      - -Ddocbook_docs=disabled
-    sources:
-      - type: archive
-        url: https://download.gnome.org/sources/libnotify/0.7/libnotify-0.7.8.tar.xz
-        sha256: 69209e0b663776a00c7b6c0e560302a8dbf66b2551d55616304f240bba66e18c
+
   - name: yt-dlp
     no-autogen: true
     no-make-install: true
@@ -45,6 +38,7 @@ modules:
       - type: archive
         url: "https://github.com/yt-dlp/yt-dlp/archive/refs/tags/2025.09.23.tar.gz"
         sha256: "ba2f0ebf715836a506f54e3062ff1448bfa8314c9db7b8ed7697a26decafdda8"
+
   - name: jsoncpp
     buildsystem: meson
     config-opts:
@@ -134,8 +128,8 @@ modules:
     buildsystem: simple
     build-commands:
       - sed -i 's|%{{APPDATA_RELEASE}}%|<release version="v5.1.0" date="2025-11-14"
-        />|' spotube-src/linux/com.github.KRTirtho.Spotube.appdata.xml
-      - install -Dm644 spotube-src/linux/com.github.KRTirtho.Spotube.appdata.xml /app/share/appdata/com.github.KRTirtho.Spotube.appdata.xml
+        />|' spotube/com.github.KRTirtho.Spotube.appdata.xml
+      - install -Dm644 spotube/com.github.KRTirtho.Spotube.appdata.xml /app/share/appdata/com.github.KRTirtho.Spotube.appdata.xml
       - desktop-file-edit spotube/spotube.desktop --set-key=Exec --set-value="spotube
         %u" --set-icon=com.github.KRTirtho.Spotube
       - install -Dm644 spotube/spotube-logo.png /app/share/icons/hicolor/128x128/apps/com.github.KRTirtho.Spotube.png
@@ -156,7 +150,3 @@ modules:
         sha256: b1ce7a5f6bbf412f30a3f34aa74ebf00260b190fef97adddfc3c3538f97fa640
         only-arches:
           - aarch64
-      - type: git
-        dest: spotube-src
-        url: https://github.com/KRTirtho/spotube
-        tag: v5.0.0


### PR DESCRIPTION
Based on https://github.com/flathub/com.github.KRTirtho.Spotube/pull/126

### Other changes

- Drop the libnotify module, which is already provided by the runtime

Fixes: https://github.com/flathub/com.github.KRTirtho.Spotube/issues/131

- Improve clean commands

- Drop the git source, which was ignored due to the only-arches entries

- Update the build-commands to use the appdata file from the tar.xz files

